### PR TITLE
Use newer syntax in routing "templates" attribute

### DIFF
--- a/src/Resources/config/routing/admin/banner.yaml
+++ b/src/Resources/config/routing/admin/banner.yaml
@@ -2,7 +2,7 @@ odiseo_sylius_banner_plugin_admin_banner:
     resource: |
         alias: odiseo_sylius_banner_plugin.banner
         section: admin
-        templates: SyliusAdminBundle:Crud
+        templates: "@SyliusAdmin/Crud"
         except: ['show']
         redirect: index
         grid: odiseo_sylius_banner_plugin_banner


### PR DESCRIPTION
To make it work with the newest Sylius (1.9) version 🚀