### PR TITLE
fix wrong order migrations namespace executed before

### DIFF
--- a/src/DependencyInjection/OdiseoSyliusBannerExtension.php
+++ b/src/DependencyInjection/OdiseoSyliusBannerExtension.php
@@ -49,6 +49,6 @@ final class OdiseoSyliusBannerExtension extends Extension implements PrependExte
 
     protected function getNamespacesOfMigrationsExecutedBefore(): array
     {
-        return [];
+        return ['Sylius\Bundle\CoreBundle\Migrations'];
     }
 }


### PR DESCRIPTION
with doctrine migrations 3 and the multi namespaces feature, you need to configure the getNamespacesOfMigrationsExecutedBefore to execute the plugin migration after sylius core.